### PR TITLE
fixed: multiple spaces cause empty values in java String[] args

### DIFF
--- a/WinRun4J/src/common/Runtime.cpp
+++ b/WinRun4J/src/common/Runtime.cpp
@@ -161,8 +161,8 @@ extern void _cdecl ParseCommandLine(LPSTR lpCmdLine, TCHAR** args, UINT& count, 
 		endPos[currentIndex] = i;
 	}
 
-	int index;
-	for (index = 0, i = (includeFirst) ? 0 : 1; i <= currentIndex; i++) {
+	int index = (includeFirst) ? count : 0;
+	for (i = 0; i <= currentIndex; i++) {
 
 		int begin = startPos[i];
 		int end = endPos[i];


### PR DESCRIPTION
Hi Peter,

specified command line (5 spaces between first and second parameter and 2 spaces between fourth and fifth):

   --first     --second --th"ir"d "--fou rth"  --fi"ve  --six   

is given to java String[] args with those values:
1. par: '--first'
2. par: ' '
3. par: ' '
4. par: ' '
5. par: ' '
6. par: '--second'
7. par: '--th"ir"d'
8. par: '--fou rth'
9. par: ' '
10. par: '--fi"ve  --six'

But I preffer those values:
1. par: '--first'
2. par: '--second'
3. par: '--th"ir"d'
4. par: '--fou rth'
5. par: '--fi"ve  --six'

If you find my patch useful, please merge it.

Thank you.

Actually, I don't know where to put some test code:

void testParseCommandLine(char\* lpCmdLine) {

```
TCHAR *args[50];
int count;
ParseCommandLine(lpCmdLine, args, &count, 1);
printf ("--------------------\nLine: '%s'\n", lpCmdLine);
int i;
for (i = 0; i < count; i++) {

    printf ("\t%i.arg :'%s'\n", i, args[i]);
}
```

}

int main(void) {

```
testParseCommandLine("--first --second");
testParseCommandLine("   --first   --second     ");
testParseCommandLine("\"--first\"  --sec\"\"ond  --th\"i  r\"d");
testParseCommandLine(" ");
testParseCommandLine("  --fir\"st  --second  ");
return EXIT_SUCCESS;
```

}

Some compare (expected x given) should be implemented too.

Sincerely Mike.
