### PR TITLE
Resource.cpp: Fixed a security bug while working with the PE's resources

### DIFF
--- a/WinRun4J/src/common/Resource.cpp
+++ b/WinRun4J/src/common/Resource.cpp
@@ -51,7 +51,7 @@ bool Resource::SetIcon(LPSTR exeFile, LPSTR iconFile)
 bool Resource::AddIcon(LPSTR exeFile, LPSTR iconFile)
 {
 	// Find the resource indices that are available
-	HMODULE hm = LoadLibrary(exeFile);
+	HMODULE hm = LoadLibraryEx(exeFile, NULL, LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE);
 	if(!hm) {
 		Log::Error("Could not load exe to add icon: %s", exeFile);
 		return false;
@@ -120,7 +120,7 @@ bool Resource::SetManifest(LPSTR exeFile, LPSTR manifestFile)
 // Prints the contents of the  INI  file
 bool Resource::ListINI(LPSTR exeFile)
 {
-	HMODULE hm = LoadLibrary(exeFile);
+	HMODULE hm = LoadLibraryEx(exeFile, NULL, LOAD_LIBRARY_AS_DATAFILE);
 	if(!hm) {
 		Log::Error("Could not load exe to list INI contents: %s", exeFile);
 		return false;
@@ -160,7 +160,7 @@ bool Resource::AddJar(LPSTR exeFile, LPSTR jarFile)
 	strcpy(jarName, &jarFile[len+1]);
 
 	// Find next available slot for JAR file
-	HMODULE hm = LoadLibrary(exeFile);
+	HMODULE hm = LoadLibraryEx(exeFile, NULL, LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE);
 	if(!hm) {
 		Log::Error("Could not load exe to add JAR: %s", exeFile);
 		return false;
@@ -370,7 +370,7 @@ BOOL EnumTypesFunc(HANDLE hModule, LPTSTR lpType, LONG lParam)
 
 bool Resource::ClearResources(LPSTR exeFile)
 {
-	HMODULE hMod = LoadLibrary(exeFile);
+	HMODULE hMod = LoadLibraryEx(exeFile, NULL, LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE);
 	if(!hMod) {
 		Log::Error("Could not load exe to clear resources: %s", exeFile);
 		return false;
@@ -405,7 +405,7 @@ bool Resource::ClearResources(LPSTR exeFile)
 
 bool Resource::ListResources(LPSTR exeFile)
 {
-	HMODULE hMod = LoadLibrary(exeFile);
+	HMODULE hMod = LoadLibraryEx(exeFile, NULL, LOAD_LIBRARY_AS_DATAFILE);
 	if(!hMod) {
 		Log::Error("Could not load exe to list resources: %s", exeFile);
 		return false;


### PR DESCRIPTION
By calling LoadLibrary, the Resource class loads the executable and runs
its DllMain (in case of a DLL). This behavior is incorrect since the user
expects the PE to be loaded as a data file in order to work with its
resources.

By replacing LoadLibrary with the call to LoadLibraryEx with the proper
flags (LOAD_LIBRARY_AS_DATAFILE flag for read-only access and
LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE for write access) the class loads
the executable without executing its code.

More information can be found under:
http://msdn.microsoft.com/en-us/library/windows/desktop/ms684179(v=vs.85).aspx

Signed-off-by: Tal Kain tal@kain.net
