### PR TITLE
Added AbstractService.shutdownRequest() to allow subclasses to override ...

### DIFF
--- a/org.boris.winrun4j/java/src/org/boris/winrun4j/AbstractService.java
+++ b/org.boris.winrun4j/java/src/org/boris/winrun4j/AbstractService.java
@@ -21,6 +21,7 @@ public abstract class AbstractService implements Service
         case SERVICE_CONTROL_STOP:
         case SERVICE_CONTROL_SHUTDOWN:
             shutdown = true;
+            shutdownRequest();
             break;
         default:
             break;
@@ -28,7 +29,11 @@ public abstract class AbstractService implements Service
         return 0;
     }
 
+    public void shutdownRequest() {
+        
+    }
+    
     public boolean isShutdown() {
         return shutdown;
-    }
+    }    
 }


### PR DESCRIPTION
...and respond to a shutdown request on a thread other than main.

This allows my main thread to wait for a signal that the Windows service is shutting down, instead of polling and sleeping.

So instead of this:

```
            while (!agentWindowsService.isShutdown()) {
                try {
                    Thread.sleep(6000);
                } catch (InterruptedException e) {
                }
```

This:

```
            _blockingQueue = new ArrayBlockingQueue<Boolean>(1);

            try {
                _blockingQueue.take();
            } catch (InterruptedException e) {
                e.printStackTrace();
            }

@Override
public void shutdownRequest() {
    try {
        _blockingQueue.put(true);
    } catch (InterruptedException e) {
        e.printStackTrace();
    }
```
